### PR TITLE
Pull cache from AWS ECR when deploying for faster builds

### DIFF
--- a/cmd/outback/build.go
+++ b/cmd/outback/build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var buildDockerArgs []string
+var buildArgs []string
 
 var buildCmd = &cobra.Command{
 	Use:   "build",
@@ -60,5 +60,5 @@ func build(clusterName string, timeout int) error {
 
 func init() {
 	rootCmd.AddCommand(buildCmd)
-	buildCmd.Flags().StringSliceVarP(&buildDockerArgs, "build-arg", "b", []string{}, "Set build-time variables")
+	buildCmd.Flags().StringSliceVarP(&buildArgs, "build-arg", "b", []string{}, "Set build-time variables")
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/koala-labs/outback/pkg/term"
@@ -9,32 +10,33 @@ import (
 
 // ImageBuild builds a docker image based on the configured dockerfile for
 // the cluster you are deploying to and tags the image with the vcs head
-func ImageBuild(repo string, tag string, dockerfile string, buildArgs []string, configBuildArgs []string) error {
+func ImageBuild(repo string, tag string, dockerfile string, buildArgs []string, configBuildArgs []string, cacheFrom []string) error {
 	image := fmt.Sprintf("%s:%s", repo, tag)
+	combinedBuildArgs := append(configBuildArgs, buildArgs...)
+	// ensure built images are optimized for remote caching
+	combinedBuildArgs = append(combinedBuildArgs, "BUILDKIT_INLINE_CACHE=1")
 
-	dockerConfigBuildArgs := make([]string, 2*len(configBuildArgs), 2*len(configBuildArgs))
-	dockerBuildArgs := make([]string, 2*len(buildArgs), 2*len(buildArgs))
+	dockerCmdBuildArgs := make([]string, 2*(len(combinedBuildArgs)), 2*(len(combinedBuildArgs)))
+	dockerCacheFromArgs := make([]string, 2*len(cacheFrom), 2*len(cacheFrom))
 
-	for i, v := range configBuildArgs {
-
-		dockerConfigBuildArgs[i*2] = "--build-arg"
-		dockerConfigBuildArgs[i*2+1] = v
-
+	for i, v := range combinedBuildArgs {
+		dockerCmdBuildArgs[i*2] = "--build-arg"
+		dockerCmdBuildArgs[i*2+1] = v
 	}
 
-	for i, v := range buildArgs {
-
-		dockerBuildArgs[i*2] = "--build-arg"
-		dockerBuildArgs[i*2+1] = v
-
+	for i, v := range cacheFrom {
+		dockerCacheFromArgs[i*2] = "--cache-from"
+		dockerCacheFromArgs[i*2+1] = v
 	}
 
 	dockerCmd := "docker"
 	dockerCmdArgs := []string{"build", "-f", dockerfile, "-t", image, "."}
-	dockerCmdBuildArgs := append([]string(dockerConfigBuildArgs), []string(dockerBuildArgs)...)
-	dockerCmdFullArgs := append([]string(dockerCmdArgs), []string(dockerCmdBuildArgs)...)
+	dockerCmdFullArgs := append(dockerCmdArgs, dockerCmdBuildArgs...)
+	dockerCmdFullArgs = append(dockerCmdFullArgs, dockerCacheFromArgs...)
 
 	cmd := exec.Command(dockerCmd, dockerCmdFullArgs...)
+	// enable BuildKit: https://docs.docker.com/engine/reference/builder/#buildkit
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 
 	if err := term.PrintStdout(cmd); err != nil {
 		return ErrImageBuild
@@ -51,6 +53,19 @@ func ImagePush(repo string, tag string) error {
 
 	if err := term.PrintStdout(cmd); err != nil {
 		return ErrImagePush
+	}
+
+	return nil
+}
+
+// ImagePull pulls an image with a specific tag from the configured repository
+func ImagePull(repo string, tag string) error {
+	image := fmt.Sprintf("%s:%s", repo, tag)
+
+	cmd := exec.Command("docker", "pull", image)
+
+	if err := term.PrintStdout(cmd); err != nil {
+		return ErrImagePull
 	}
 
 	return nil

--- a/pkg/docker/error.go
+++ b/pkg/docker/error.go
@@ -4,5 +4,6 @@ import "errors"
 
 var (
 	ErrImageBuild = errors.New("Could not build docker image")
-	ErrImagePush  = errors.New("Could not push docker image. Are you logged in to ECR? http://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth\nHint: `$(aws ecr get-login --no-include-email --region us-west-1)`\nDon't forget your --profile if you use one")
+	ErrImagePush  = errors.New("Could not push docker image. Are you logged in to ECR? http://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth\nHint: `$(aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin)`\nDon't forget your --profile if you use one")
+	ErrImagePull  = errors.New("Could not push docker image. Are you logged in to ECR? http://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth\nHint: `$(aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin)`\nDon't forget your --profile if you use one")
 )


### PR DESCRIPTION
# What

Pull the last previously deployed image for a cluster when deploying to serve as the cache base for the new build.

# Why

Pulling the last image should help speed up some `outback deploy` by ensuring docker can re-use some of the work that happened during previous deploys. This is especially helpful during CI deploys when most times there is no docker cache.

# How

Before building all images use the special `BUILDKIT_INLINE_CACHE=1` build argument to tell docker that we plan to use the built artifact for caching. Then while building the image use the  `cache-from` flag to tell docker to use an old image as the cache base

# CC 🐨
