### PR TITLE
Allow for configurable number of max attemps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ On first run, if there is not a `.outback/config.json` config present in your cu
 
 Outback will relies on this config to run its operations.
 
+In addition, some AWS settings can be configured globally through environment variables:
+
+| ENV var                 | description                                                                          | default |
+| ----------------------- | ------------------------------------------------------------------------------------ | ------- |
+| `AWS_ACCESS_KEY_ID`     | AWS access key (takes precedence over the value in `~/.aws/credentials`)             |         |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key (takes precedence over the value in `~/.aws/credentials`)      |         |
+| `AWS_MAX_ATTEMPTS`      | The maximum number attempts to make for an AWS requests before failing the operation | -1      |
+
 ### Commands
 
 - outback deploy


### PR DESCRIPTION
# What

Read the env var `AWS_MAX_ATTEMPTS` to set max number of retries for the AWS SDK operations

# Why

Sometimes `outback deploy` will fail because AWS is throttling a specific API action (e.g. `DescribeTaskDefinition` needs to be called multiple times during one deploy). Throttling limits are hard to predict because the depend on the AWS account settings and the number of concurrent deploys. 

Allowing the max number of AWS SDK retries to be configured at runtime should make throttling errors less likely.

# How

Read the value of `AWS_MAX_ATTEMPTS` and pass it to the `aws.Config` `MaxRetries` field.

if `AWS_MAX_ATTEMPTS` does not exists default to -1 which is the same default that `aws.Config` uses. See https://pkg.go.dev/github.com/aws/aws-sdk-go/aws#Config.MaxRetries
# CC 🐨
