### PR TITLE
Pull latest docker image for a service in a cluster

### DIFF
--- a/cmd/outback/errors.go
+++ b/cmd/outback/errors.go
@@ -32,6 +32,11 @@ var (
 	ErrCantFollowWithEndTime = errors.New("Could not follow logs because an end time was given")
 )
 
+var (
+	ErrorMissingClusterInput = errors.New("A cluster name must be specified using the --cluster flag")
+	ErrorMissingServiceInput = errors.New("A service name must be specified using the --service flag")
+)
+
 // handleError is intended to be called with an error return to simplify error handling
 // Usage:
 // foo, err := GetFoo()

--- a/cmd/outback/pull_latest.go
+++ b/cmd/outback/pull_latest.go
@@ -8,7 +8,7 @@ import (
 
 var pullLatestCmd = &cobra.Command{
 	Use:   "pull-latest",
-	Short: "Pull the latest docker image from a deployment",
+	Short: "Pull the latest deployed docker image from a service",
 	Long: `A cluster must be specified via the --cluster flag, and a service must be specified via the --cluster flag.
 	The --verbose flag can be input to enable verbose output.
 	The --login flag can be input to login to AWS ECR.`,
@@ -20,6 +20,14 @@ func runPullLatest(cmd *cobra.Command, args []string) error {
 }
 
 func pullLatest(clusterName string, serviceName string) error {
+	if clusterName == "" {
+		return ErrorMissingClusterInput
+	}
+
+	if serviceName == "" {
+		return ErrorMissingServiceInput
+	}
+
 	outback := Outback.New(awsConfig)
 
 	cluster, err := cfg.getCluster(clusterName)
@@ -48,6 +56,8 @@ func pullLatest(clusterName string, serviceName string) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Found image at %s:%s\nPulling...\n", cfg.Repo, commit)
 
 	// Pull latest image
 	err = outback.LoginPullImage(cfg.Repo, commit)

--- a/cmd/outback/pull_latest.go
+++ b/cmd/outback/pull_latest.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	Outback "github.com/koala-labs/outback/pkg/outback"
+	"github.com/spf13/cobra"
+)
+
+var pullLatestCmd = &cobra.Command{
+	Use:   "pull-latest",
+	Short: "Pull the latest docker image from a deployment",
+	Long: `A cluster must be specified via the --cluster flag, and a service must be specified via the --cluster flag.
+	The --verbose flag can be input to enable verbose output.
+	The --login flag can be input to login to AWS ECR.`,
+	RunE: runPullLatest,
+}
+
+func runPullLatest(cmd *cobra.Command, args []string) error {
+	return pullLatest(flagCluster, flagService)
+}
+
+func pullLatest(clusterName string, serviceName string) error {
+	outback := Outback.New(awsConfig)
+
+	cluster, err := cfg.getCluster(clusterName)
+	if err != nil {
+		return err
+	}
+
+	ecsCluster, err := outback.GetCluster(cluster.Name)
+	if err != nil {
+		return err
+	}
+
+	ecsService, err := outback.GetService(ecsCluster, serviceName)
+	if err != nil {
+		return err
+	}
+
+	// Get the Service's TaskDefinition
+	ecsTaskDef, err := outback.GetTaskDefinition(ecsCluster, ecsService)
+	if err != nil {
+		return err
+	}
+
+	// Get the commit from the last TaskDefinition if it exists
+	commit, err := outback.GetLastDeployedCommit(*ecsTaskDef.TaskDefinitionArn)
+	if err != nil {
+		return err
+	}
+
+	// Pull latest image
+	err = outback.LoginPullImage(cfg.Repo, commit)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully pulled the latest image from :\n\t%s:%s\n", cfg.Repo, commit)
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(pullLatestCmd)
+}


### PR DESCRIPTION
# What

Adds a command to pull the latest Docker image used by a service in a cluster.

# Why

Almost of the logic to fetch the latest Docker image used by a service in a cluster is already in Outback. The ability to fetch an image for download would make the Outback tool in integral part of CI pipeline with regard to building near-production Docker containers to run unit tests and other code quality tools.

# How

This new command makes heavy use of the existing configuration parser and Outback Docker wrapper to determine the latest image for a given service and cluster.

# CC 🐨
